### PR TITLE
feat: Add 'suggest' command

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "git-commit-suggestions",
-  "version": "0.0.1",
+  "name": "auto-commit-ai",
+  "version": "0.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "git-commit-suggestions",
-      "version": "0.0.1",
+      "name": "auto-commit-ai",
+      "version": "0.0.2",
       "dependencies": {
         "@types/axios": "^0.14.0",
         "axios": "^1.3.4",

--- a/package.json
+++ b/package.json
@@ -24,8 +24,12 @@
   "contributes": {
     "commands": [
       {
-        "command": "extension.gitCommitSuggestions",
-        "title": "Auto Commit AI"
+        "command": "autoCommitAI.suggest",
+        "title": "Auto Commit AI: Suggest Commit Message"
+      },
+      {
+        "command": "autoCommitAI.commit",
+        "title": "Auto Commit AI: Commit With Suggested Message"
       }
     ],
     "configuration": [

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,151 +1,170 @@
 import * as vscode from 'vscode';
 import axios, { AxiosError } from 'axios';
 import git from 'simple-git';
-
 import { Configuration, OpenAIApi } from 'openai';
 
+export async function activate(context: vscode.ExtensionContext) {
+  console.log('Congratulations, your extension "auto-commit-ai" is now active!');
+
+  const suggest = async () => {
+    const git = vscode.extensions.getExtension('vscode.git')?.exports.getAPI(1);
+    if (!git) {
+      vscode.window.showErrorMessage('Unable to load Git Extension');
+      return;
+    }
+
+    const selectedCommitMessage =  await getSuggestedCommitMessage();
+    
+    if (selectedCommitMessage) {
+      vscode.commands.executeCommand('workbench.view.scm');
+
+      const commitMessage = removeNumberFromCommitMessage(selectedCommitMessage);
+
+      for (const repo of git.repositories) {
+        repo.inputBox.value = commitMessage;
+      }
+    }
+  };
+
+  const commit = async () => {
+    const selectedCommitMessage = await getSuggestedCommitMessage();
+  
+    if (selectedCommitMessage) {
+      const terminal = vscode.window.activeTerminal || vscode.window.createTerminal();
+      terminal.show();
+    
+      const commitMessageWithoutNumber = removeNumberFromCommitMessage(selectedCommitMessage);
+      terminal.sendText(`git commit -m "${commitMessageWithoutNumber}"`);
+    }
+  };
+
+  context.subscriptions.push(vscode.commands.registerCommand('autoCommitAI.commit', commit));
+  context.subscriptions.push(vscode.commands.registerCommand('autoCommitAI.suggest', suggest));
+}
+
+function removeNumberFromCommitMessage(commitMessage: string) {
+  return commitMessage.replace(/^\d+\.\s*/, '');
+}
+
 function isRateLimitError(error: AxiosError) {
-	return error.response?.status === 429;
+  return error.response?.status === 429;
 }
 
 async function hasUnstagedChanges() {
-	const workspaceFolders = vscode.workspace.workspaceFolders;
-	if (!workspaceFolders) {
-		return false;
-	}
+  const workspaceFolders = vscode.workspace.workspaceFolders;
+  if (!workspaceFolders) {
+    return false;
+  }
 
-	const gitInstance = git(workspaceFolders[0].uri.fsPath);
-	const statusSummary = await gitInstance.status();
+  const gitInstance = git(workspaceFolders[0].uri.fsPath);
+  const statusSummary = await gitInstance.status();
 
-	return statusSummary.files.some(file => file.index !== 'A' && file.index !== 'M');
+  return statusSummary.files.some(file => file.index !== 'A' && file.index !== 'M');
 }
 
-export async function activate(context: vscode.ExtensionContext) {
-	console.log('Congratulations, your extension "git-commit-suggestions" is now active!');
-  
-	// Register the command
-	const disposable = vscode.commands.registerCommand('extension.gitCommitSuggestions', async () => {
-	  const apiKey = await getOpenAIKey();
-  
-	  if (await hasUnstagedChanges()) {
-		const terminal = vscode.window.activeTerminal || vscode.window.createTerminal();
-		terminal.show();
-		terminal.sendText('git status');
-		vscode.window.showInformationMessage('You need to stage your changes with "git add ." before using this extension.');
-		return;
-	  }
-  
-	  if (!apiKey) {
-		vscode.window.showErrorMessage('Please provide your OpenAI API key to use this extension.');
-		return;
-	  }
-  
-	  // Get the staged changes
-	  const stagedChanges = await getStagedChanges();
-  
-	  // Check if there are no staged changes
-	  if (!stagedChanges || stagedChanges.trim() === '') {
-		vscode.window.showInformationMessage('There are no changes to commit.');
-		return;
-	  }
-  
-	  const suggestions = await generateCommitSuggestions(apiKey, stagedChanges, 5);
-  
-	  if (!suggestions || suggestions.length === 0) {
-		return;
-	  }
-  
-	  const selectedCommitMessage = await vscode.window.showQuickPick(suggestions, {
-		placeHolder: 'Select a commit message',
-		ignoreFocusOut: true,
-	  });
-  
-	  if (selectedCommitMessage) {
-		const terminal = vscode.window.activeTerminal || vscode.window.createTerminal();
-		terminal.show();
-  
-		const commitMessageWithoutNumber = selectedCommitMessage.replace(/^\d+\.\s*/, '');
-		terminal.sendText(`git commit -m "${commitMessageWithoutNumber}"`);
-	  }
-	});
-  
-	context.subscriptions.push(disposable);
+async function getSuggestedCommitMessage() {
+  const apiKey = await getOpenAIKey();
+
+  if (await hasUnstagedChanges()) {
+    const terminal = vscode.window.activeTerminal || vscode.window.createTerminal();
+    terminal.show();
+    terminal.sendText('git status');
+    vscode.window.showInformationMessage('You need to stage your changes with "git add ." before using this extension.');
+    return;
   }
-  
+
+  if (!apiKey) {
+    vscode.window.showErrorMessage('Please provide your OpenAI API key to use this extension.');
+    return;
+  }
+
+  // Get the staged changes
+  const stagedChanges = await getStagedChanges();
+
+  // Check if there are no staged changes
+  if (!stagedChanges || stagedChanges.trim() === '') {
+    vscode.window.showInformationMessage('There are no changes to commit.');
+    return;
+  }
+
+  const suggestions = await generateCommitSuggestions(apiKey, stagedChanges, 5);
+
+  if (!suggestions || suggestions.length === 0) {
+    return;
+  }
+
+  return await vscode.window.showQuickPick(suggestions, {
+    placeHolder: 'Select a commit message',
+    ignoreFocusOut: true,
+  });
+};
 
 async function getOpenAIKey(forceNewKey = false): Promise<string | undefined> {
-	const configuration = vscode.workspace.getConfiguration('gitCommitSuggestions');
-	let apiKey = forceNewKey ? undefined : configuration.get<string>('openAIKey');
+  const configuration = vscode.workspace.getConfiguration('gitCommitSuggestions');
+  let apiKey = forceNewKey ? undefined : configuration.get<string>('openAIKey');
 
-	if (!apiKey) {
-		apiKey = await vscode.window.showInputBox({
-			prompt: 'Digite sua chave da API OpenAI',
-			ignoreFocusOut: true,
-			password: true,
-		});
+  if (!apiKey) {
+    apiKey = await vscode.window.showInputBox({
+      prompt: 'Digite sua chave da API OpenAI',
+      ignoreFocusOut: true,
+      password: true,
+    });
 
-		if (apiKey) {
-			configuration.update('openAIKey', apiKey, vscode.ConfigurationTarget.Global);
-		}
-	}
+    if (apiKey) {
+      configuration.update('openAIKey', apiKey, vscode.ConfigurationTarget.Global);
+    }
+  }
 
-	return apiKey;
+  return apiKey;
 }
-
-
 
 async function getStagedChanges(): Promise<string> {
-	const workspaceFolders = vscode.workspace.workspaceFolders;
-	if (!workspaceFolders) {
-	  return '';
-	}
-  
-	const gitInstance = git(workspaceFolders[0].uri.fsPath);
-	const diffSummary = await gitInstance.diff(['--staged']);
-  
-	return diffSummary;
+  const workspaceFolders = vscode.workspace.workspaceFolders;
+  if (!workspaceFolders) {
+    return '';
   }
   
-
-
-
-async function generateCommitSuggestions(apiKey: string, prompt: string, numSuggestions: number): Promise<string[] | undefined> {
-	const configuration = new Configuration({
-		apiKey: apiKey,
-	});
-	const openai = new OpenAIApi(configuration);
-
-	try {
-		const response = await openai.createCompletion({
-			model: 'text-davinci-003',
-			prompt: `Given the Git commit history: ${prompt}\n\nSuggest a commit message. If a new feature was added, the message should start with "feat: ", if a fix was made it should start with "fix: " :\n`,
-			temperature: 0.5,
-			max_tokens: 50,
-			top_p: 1,
-			frequency_penalty: 0,
-			presence_penalty: 0,
-			n: numSuggestions,
-		});
-
-		const uniqueSuggestions = Array.from(new Set(response.data.choices.map(choice => (choice.text ?? '').trim())));
-		const suggestions = uniqueSuggestions.map((suggestion, index) => `${index + 1}. ${suggestion}`);
-
-		return suggestions;
-	} catch (error) {
-		if (axios.isAxiosError(error) && isRateLimitError(error)) {
-			vscode.window.showErrorMessage('Sua chave da API expirou. Por favor, insira outra chave.');
-			const newApiKey = await getOpenAIKey(true);
-			if (newApiKey) {
-				return generateCommitSuggestions(newApiKey, prompt, numSuggestions);
-			}
-		} else {
-			throw error;
-		}
-	}
-
-	// Adicione um retorno explícito de 'undefined' no final da função
-	return undefined;
+  const gitInstance = git(workspaceFolders[0].uri.fsPath);
+  const diffSummary = await gitInstance.diff(['--staged']);
+  
+  return diffSummary;
 }
 
+async function generateCommitSuggestions(apiKey: string, prompt: string, numSuggestions: number): Promise<string[] | undefined> {
+  const configuration = new Configuration({
+    apiKey: apiKey,
+  });
+  const openai = new OpenAIApi(configuration);
 
+  try {
+    const response = await openai.createCompletion({
+      model: 'text-davinci-003',
+      prompt: `Given the Git commit history: ${prompt}\n\nSuggest a commit message. If a new feature was added, the message should start with "feat: ", if a fix was made it should start with "fix: " :\n`,
+      temperature: 0.5,
+      max_tokens: 50,
+      top_p: 1,
+      frequency_penalty: 0,
+      presence_penalty: 0,
+      n: numSuggestions,
+    });
+
+    const uniqueSuggestions = Array.from(new Set(response.data.choices.map(choice => (choice.text ?? '').trim())));
+    const suggestions = uniqueSuggestions.map((suggestion, index) => `${index + 1}. ${suggestion}`);
+
+    return suggestions;
+  } catch (error) {
+    if (axios.isAxiosError(error) && isRateLimitError(error)) {
+      vscode.window.showErrorMessage('Sua chave da API expirou. Por favor, insira outra chave.');
+      const newApiKey = await getOpenAIKey(true);
+      if (newApiKey) {
+        return generateCommitSuggestions(newApiKey, prompt, numSuggestions);
+      }
+    } else {
+      throw error;
+    }
+  }
+
+  // Adicione um retorno explícito de 'undefined' no final da função
+  return undefined;
+}
 


### PR DESCRIPTION
I renamed the current command to "commit" and added another one named "suggest"
The "commit" command works just like before, and the new "suggest" command does almost the same except it writes the commit message into the sourceControl inputfield without commiting directly